### PR TITLE
Add a privacy policy link

### DIFF
--- a/templates/structure.html
+++ b/templates/structure.html
@@ -40,6 +40,7 @@
       <a href="https://github.com/teamsilverblue"><svg class="icon"><use href="/public/svg-sprites.svg#github" /></svg>Github</a>
       <a href="http://webchat.freenode.net/?channels=silverblue"><svg class="icon"><use href="/public/svg-sprites.svg#hash" /></svg>IRC</a>
       <a href="https://community.teamsilverblue.org"><svg class="icon"><use href="/public/svg-sprites.svg#comments" /></svg>Community</a>
+      <a href="https://fedoraproject.org/wiki/Legal:PrivacyPolicy">Privacy Policy</a>
     </nav>
     <p id="copyright">
       &copy; 2018 Team Silverblue.<br>A Fedora initiative.


### PR DESCRIPTION
For now, simply link to the Fedora privacy policy in the footer.