### PR TITLE
Remove the blog links

### DIFF
--- a/pages/other.html
+++ b/pages/other.html
@@ -26,25 +26,5 @@
   <li><a href="/public/container-commandos.pdf">Container commandos</a>
   </ul>
 
-  <p>Matthias has written a series of blog posts about his experience learning his
-  way around Silverblue, when it was still called Fedora Atomic Workstation:</p>
-
-  <ul>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/08/first-steps-with-fedora-atomic-workstation/">First steps</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/11/fedora-atomic-workstation-what-about-apps/">What about apps?</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/14/fedora-atomic-workstation-building-flatpaks/">Building flatpaks</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/16/fedora-atomic-workstation-for-development/">For development</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/21/fedora-atomic-workstation-works-on-the-beach/">Works on the beach</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/02/24/fedora-atomic-workstation-on-the-road/">On the road</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/03/08/fedora-atomic-workstation-trying-things-out-the-easy-way/">Trying things out the easy way</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/03/16/fedora-atomic-workstation-ruling-the-commandline/">Ruling the commandline</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/03/22/fedora-atomic-workstation-almost-fool-proof/">Almost foolproof</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/04/03/fedora-atomic-workstation-beta/">Beta</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/04/16/fedora-atomic-workstation-developer-tools/">Developer tools</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/04/27/fedora-atomic-workstation-developer-tools-continued/">Developer tools, continued</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/04/29/fedora-atomic-workstation-theming-possible/">Theming possible</a>
-  <li><a href="https://blogs.gnome.org/mclasen/2018/05/04/fedora-atomic-workstation-getting-comfortable-with-gnome-builder/">Getting comfortable with GNOME Builder</a>
-  </ul>
-
 </article>
 {{end}}


### PR DESCRIPTION
These are being moved to the 'Elsewhere' section in the main site.

This is a companion to https://github.com/teamsilverblue/silverblue-site/pull/29