### PR TITLE
Add side-by-side installation instructions

### DIFF
--- a/pages/installing-side-by-side.html
+++ b/pages/installing-side-by-side.html
@@ -1,0 +1,89 @@
+<!-- See structure.html for the template names used here and their position in the layout. -->
+{{define "title"}}Team Silverblue &mdash; Documentation{{end}}
+
+{{define "body"}}
+<article>
+  <h1>Installing Silverblue, side-by-side</h1>
+
+  <p>A really neat feature of OSTree is that you can parallel install <em>inside</em> your
+  existing OS' filesystem. Let's try that, we first make sure we have the ostree packages:</p>
+
+  <pre>yum -y install ostree ostree-grub2</pre>
+
+  <p>Before proceeding further, make sure that you have enough space in your root filesystem.
+  The recommended minimum is 10GB (the Silverblue repo we are going to pull takes ~7GB on disk).
+  Note that ostree will refuse to continue if you go below 3% of free space, so there's no
+  risk of actually running out of space.</p>
+
+  <p>Next, we add /ostree/repo to the filesystem:</p>
+
+  <pre>ostree admin init-fs /</pre>
+
+  <p>Add a remote which points to the Silverblue content:</p>
+
+  <pre>ostree remote add --set=gpgkeypath=/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-28-primary atomic https://kojipkgs.fedoraproject.org/atomic/repo/</pre>
+
+  <p>If you do not have the Fedora 28 GPG primary key, you can get it from
+  <a href="https://getfedora.org/keys/">https://getfedora.org/keys/</a>.
+  Alternatively, if you really need to, you can turn off GPG verification using the
+  --no-gpg-verify option.</p>
+
+  <p>Pull down the content (you can interrupt and restart this):</p>
+
+  <pre>ostree --repo=/ostree/repo pull atomic:fedora/28/x86_64/workstation</pre>
+
+  <p>Initialize an OS for this, which acts as a state root.</p>
+
+  <pre>ostree admin os-init fedora</pre>
+
+  <p><b>For EFI systems:</b> currently ostree uses the presence of /boot/grub2/grub.cfg
+  to detect a BIOS system, but that can be present on systems booted with EFI as well.
+  If you boot with EFI (/sys/firmware/efi exists), then you need to move /boot/grub2/grub.cfg
+  aside:</p>
+
+  <pre>mv /boot/grub2/grub.cfg /boot/grub2/grub.cfg.bak</pre>
+
+  <p>Since this file is not used on a EFI system, this won't break the operation of your
+  current system. While you are at it, back up your existing grub config:</p>
+
+  <pre>cp /boot/efi/EFI/fedora/grub.cfg /boot/efi/EFI/fedora/grub.cfg.bak</pre>
+
+  <p>And now, we can deploy the commit we just pulled down. The --karg-proc-cmdline switch
+  will ensure that the current kernel arguments you used for the current boot will also apply
+  to the OSTree boot.</p>
+
+  <pre>ostree admin deploy --os=fedora --karg-proc-cmdline atomic:fedora/28/x86_64/workstation</pre>
+
+  <p>To initialize this root, you'll need to copy over your /etc/fstab, /etc/locale.conf,
+  /etc/default/grub at least, along with the ostree remote that we added:</p>
+
+  <pre>for i in /etc/fstab /etc/default/grub /etc/locale.conf /etc/ostree/remotes.d/atomic.conf ; do cp $i /ostree/deploy/fedora/deploy/$checksum.0/$i; done</pre>
+
+  <p>where $checksum is whatever the checksum of the deployment is; there should only be a
+  single directory there if this is your first deployment.</p>
+
+  <p>If you have a separate /home mount point, you'll need to change that fstab copy to
+  refer to /var/home. If you don't have a separate /home mount point, then you need to make
+  sure that a symlink will be created:</p>
+
+  <pre>echo 'L /var/home - - - - ../sysroot/home' > /ostree/deploy/fedora/deploy/$checksum.0/etc/tmpfiles.d/00rpm-ostree.conf</pre>
+
+  <p>You'll also need to copy your user entry from /etc/passwd, /etc/group, and /etc/shadow
+  into the new /etc/, and add yourself to the wheel group in /etc/group. Don't copy just
+  copy these files literally, however, since the system users and groups won't be the same.</p>
+
+  <p><b>For BIOS systems:</b> while ostree regenerated the bootloader configuration,
+  it writes config into /boot/loader/grub.cfg. On a current grubby system, you'll need
+  to copy that version over:</p>
+
+  <pre>cp /boot/loader/grub.cfg /boot/grub2/grub.cfg</pre>
+
+  <p>Note that you will have to repeat this every time a new tree is created, so it may
+  be more convenient to just create a symlink:</p>
+
+  <pre>cd /boot/grub2
+rm grub.cfg
+ln -s ../loader/grub.cfg .</pre>
+
+</article>
+{{end}}

--- a/pages/installing.html
+++ b/pages/installing.html
@@ -23,7 +23,7 @@
         <li>If yes, you should consider using the <a href="#manual-partition">manual partitioning</a>
             method during the install process.</li>
         <li>Alternatively, if your system has an existing Fedora install on it, you could
-            use the <a href="#side-by-side">side-by-side</a> install method.</li>
+            use the <a href="/installing-side-by-side">side-by-side</a> install method.</li>
       </ul>
     <li>Do you want to do a fresh install and do not care about retaining any existing
         data on your system?</li>
@@ -202,13 +202,6 @@
 
   <p>Once you have started the installer, you can move on to the <a href="#user-config">User Configuration</a>
   section of this guide.</p>
-
-  <h2 id="side-by-side">Installing Side-by-Side on an Existing System</h2>
-
-  <p>There will be detailed instructions on how to install Silverblue along side an
-  existing Fedora installation in the near future.  If you are would like to explore
-  this method now, you can use <a href="https://pagure.io/workstation-ostree-config/blob/master/f/README-install-inside.md">these instructions</a>
-  from the <code>workstation-ostree-config</code> repo.</p>
 
   <h2 id="user-config">User Configuration</h2>
 


### PR DESCRIPTION
This is just the content from workstation-ostree-config,
integrated in our docs here.